### PR TITLE
Fixed Content-Lenght in the response

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,8 @@ app.get('/:id', function(req, res) {
 
   res.writeHead(200, {
     'Content-Type': 'application/zip',
-    'Content-disposition': 'attachment; filename="' + filename + '"'
+    'Content-disposition': 'attachment; filename="' + filename + '"',
+    'Content-Lenght':filename.size
   })
   archive.pipe(res)
 


### PR DESCRIPTION
This header is needed for download accelerators, and more commonly for all users to know the progress of the download

**THIS THING NEEDS TESTING !** Not sure if it works, try it before merging